### PR TITLE
add flag -B to define custom banner

### DIFF
--- a/sshd.go
+++ b/sshd.go
@@ -16,15 +16,17 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
 const (
-	DefPort         = 22
-	DefBanner       = "SSH-2.0-OpenSSH_6.1p2"
-	DefCacheTimeout = 1 * time.Hour
-	DefKeyBits      = 2048
-	CredBacklog     = 2048
+	DefPort            = 22
+	DefRFCBannerPrefix = "SSH-2.0-"
+	DefBanner          = "SSH-2.0-OpenSSH_6.1p2"
+	DefCacheTimeout    = 1 * time.Hour
+	DefKeyBits         = 2048
+	CredBacklog        = 2048
 )
 
 var (
@@ -138,6 +140,10 @@ func genPrivateKey(bits int) []byte {
 
 func main() {
 	flag.Parse()
+	if !strings.HasPrefix(*bannerString, DefRFCBannerPrefix) || !(len(*bannerString) > len(DefRFCBannerPrefix)) {
+		log.Fatal("ERROR: SSHv2 banner not RFC compliant, must start with SSH-2.0- and contain at least one additional character", *bannerString)
+	}
+
 	if *logFile != "" {
 		f, err := os.OpenFile(*logFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		if err != nil {

--- a/sshd.go
+++ b/sshd.go
@@ -28,10 +28,11 @@ const (
 )
 
 var (
-	listenPort  = flag.Int("p", DefPort, "port to listen on")
-	hostKeyFile = flag.String("h", "", "server host key private pem file")
-	logFile     = flag.String("l", "", "output log file")
-	attackMode  = flag.Bool("A", false, "turn on attack mode")
+	listenPort   = flag.Int("p", DefPort, "port to listen on")
+	hostKeyFile  = flag.String("h", "", "server host key private pem file")
+	logFile      = flag.String("l", "", "output log file")
+	attackMode   = flag.Bool("A", false, "turn on attack mode")
+	bannerString = flag.String("B", DefBanner, "server SSH banner")
 )
 
 type Cred struct {
@@ -97,7 +98,7 @@ L:
 			cConfig := &ssh.ClientConfig{
 				User:          cred.user,
 				Auth:          []ssh.AuthMethod{ssh.Password(cred.pass)},
-				ClientVersion: DefBanner,
+				ClientVersion: *bannerString,
 			}
 			conn, _, _, err := ssh.NewClientConn(c, target, cConfig)
 			if err != nil {
@@ -156,7 +157,7 @@ func main() {
 				log.Fatalf("bad host or port: %s\n", conn.RemoteAddr().String())
 			}
 			log.Printf("Attacker %s tried: %s:%s\n", host, conn.User(), pass)
-			if *attackMode  && host != "127.0.0.1" {
+			if *attackMode && host != "127.0.0.1" {
 				attCh <- &Attacker{
 					Cred{conn.User(), string(pass)},
 					host,
@@ -164,7 +165,7 @@ func main() {
 			}
 			return nil, errors.New("password auth failed") // always fail
 		},
-		ServerVersion: DefBanner,
+		ServerVersion: *bannerString,
 	}
 	var pemBytes []byte
 	if *hostKeyFile != "" {


### PR DESCRIPTION
I have added a simple `-B` flag to allow specification of a custom SSH banner. It validates that the banner is an RFC compliant SSH protocol version 2 banner string